### PR TITLE
Only accept/download CMake version 3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.pm linguist-language=Perl
 *.t linguist-language=Perl
 *.h linguist-language=C
+alienfile linguist-language=Perl

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,9 +18,17 @@ jobs:
       matrix:
         cip:
           - env: ALIEN_INSTALL_TYPE=share
-            tag: "5.37"
+            tag: "5.41"
           - env: ALIEN_INSTALL_TYPE=system
-            tag: "5.37"
+            tag: "5.41"
+          - env: ALIEN_INSTALL_TYPE=share
+            tag: "5.40"
+          - env: ALIEN_INSTALL_TYPE=system
+            tag: "5.40"
+          - env: ALIEN_INSTALL_TYPE=share
+            tag: "5.38"
+          - env: ALIEN_INSTALL_TYPE=system
+            tag: "5.38"
           - env: ALIEN_INSTALL_TYPE=share
             tag: "5.36"
           - env: ALIEN_INSTALL_TYPE=system

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -88,7 +88,7 @@ jobs:
 
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Bootstrap CIP
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -101,7 +101,7 @@ jobs:
           cip cache-key
 
       - name: Cache CPAN modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cip
           key: ${{ runner.os }}-build-${{ steps.cache-key.outputs.key }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: macOS-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Perl
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -38,7 +38,7 @@ jobs:
           ls -l perlversion.txt
 
       - name: Cache CPAN modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/perl5
           key: ${{ runner.os }}-build-${{ hashFiles('perlversion.txt') }}

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -17,7 +17,7 @@ jobs:
       CIP_TAG: static
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Bootstrap CIP
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Perl
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -42,7 +42,7 @@ jobs:
           dir perlversion.txt
 
       - name: Cache CPAN modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: c:\cx
           key: ${{ runner.os }}-build-${{ hashFiles('perlversion.txt') }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /Alien-cmake3-*
 /.build
 *.swp
+*.old
+*.orig

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "pls.perlcritic.perlcriticrc": "perlcriticrc",
+    "pls.inc": [
+        "$ROOT_PATH/lib"
+    ]
+}

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Only use CMake 3.x, not 4.x (gh#20, gh#21)
 
 0.08      2021-07-16 12:05:39 -0600
   - Documentation improvements (gh#3, gh#15)

--- a/alienfile
+++ b/alienfile
@@ -33,11 +33,15 @@ probe sub {
     if($old_cmake_version)
     {
       my($major) = $old_cmake_version =~ /^([0-9])\./;
-      if($major >= 3)
+      if($major == 3)
       {
         $build->install_prop->{my_old_cmake_use} = 1;
         $build->log("GOOD found cmake version $old_cmake_version");
         return 'system' unless $ENV{ALIEN_CMAKE_FROM_SOURCE};
+      }
+      elsif ($major > 3)
+      {
+        $build->log("TOO NEW found cmake version $old_cmake_version");
       }
       else
       {
@@ -110,7 +114,7 @@ share {
   {
     start_url 'https://cmake.org/download/';
     plugin Download => (
-      filter  => qr/^cmake-[0-9\.]+-\Q$binary_release_name\E\.\Q$binary_format\E$/,
+      filter  => qr/^cmake-3\.[0-9\.]+-\Q$binary_release_name\E\.\Q$binary_format\E$/,
       version => qr/([0-9\.]+)/,
       ($^O eq 'MSWin32' ? (bootstrap_ssl => 1) : ()),
     );
@@ -147,7 +151,7 @@ share {
   {
     start_url 'https://cmake.org/download/';
     plugin Download => (
-      filter  => qr/^cmake-[0-9\.]+\.tar.gz$/,
+      filter  => qr/^cmake-3\.[0-9\.]+\.tar.gz$/,
       version => qr/([0-9\.]+)/,
     );
     plugin Extract => 'tar.gz';

--- a/dist.ini
+++ b/dist.ini
@@ -2,11 +2,11 @@ name             = Alien-cmake3
 author           = Graham Ollis <plicease@cpan.org>
 license          = Perl_5
 copyright_holder = Graham Ollis
-copyright_year   = 2017-2022
+copyright_year   = 2017-2024
 version          = 0.08
 
 [@Author::Plicease]
-:version      = 2.69
+:version      = 2.79
 release_tests = 1
 github_user   = PerlAlien
 installer     = Author::Plicease::MakeMaker

--- a/lib/Alien/cmake3.pm
+++ b/lib/Alien/cmake3.pm
@@ -5,7 +5,7 @@ use warnings;
 use 5.008001;
 use base qw( Alien::Base );
 
-# ABSTRACT: Find or download or build cmake 3 or better
+# ABSTRACT: Find or download or build cmake 3
 # VERSION
 
 =head1 SYNOPSIS
@@ -36,7 +36,7 @@ From L<alienfile>
 =head1 DESCRIPTION
 
 This L<Alien> distribution provides an external dependency on the build tool C<cmake>
-version 3.0.0 or better.  C<cmake> is a popular alternative to autoconf.
+version 3.x.x.  C<cmake> is a popular alternative to autoconf.
 
 =head1 METHODS
 
@@ -80,7 +80,7 @@ these ways:
 
 It integrates better with L<Alien>s that are based on that technology.
 
-=item L<Alien::cmake3> will provide version 3.0.0 or better
+=item L<Alien::cmake3> will provide version 3.x.x
 
 L<Alien::CMake> will provide 2.x.x on some platforms where more recent binaries are not available.
 
@@ -136,7 +136,7 @@ binary share install (even if available), and instead a source share install.
 
 =head1 CAVEATS
 
-If you do not have a system C<cmake> of at least 3.0.0 available, then a share install
+If you do not have a system C<cmake> version 3.x.x available, then a share install
 will be attempted.
 
 Binary share installs are attempted on platforms for which the latest version of C<cmake>
@@ -154,7 +154,7 @@ you have some options:
 
 =item Install system version of C<cmake>
 
-If you can find an older version better than 3.0.0 that is supported by your operating
+If you can find an older version of C<cmake> 3.x.x that is supported by your operating
 system.
 
 =item Force a source code install


### PR DESCRIPTION
It would be very confusing if a module named Alien::cmake3 installed or used CMake 4. Also, CMake 4 breaks compatibility with projects that declare a version requirement < 3.5, and breaks both this module's tests and Alien::Build's if this is installed.

Fixes #20 