### PR TITLE
update start URL now that 3.x is no longer on the main download page

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Update URL now that 3.x is not on the main download page (gh#23, gh#24)
 
 0.09      2025-04-02 12:54:07 -0600
   - Only use CMake 3.x, not 4.x (gh#20, gh#21)

--- a/alienfile
+++ b/alienfile
@@ -112,7 +112,7 @@ share {
   # For platforms where there is a binary release, use that:
   if($binary_release_name && !$ENV{ALIEN_CMAKE_FROM_SOURCE})
   {
-    start_url 'https://cmake.org/download/';
+    start_url 'https://cmake.org/files/v3.31/';
     plugin Download => (
       filter  => qr/^cmake-3\.[0-9\.]+-\Q$binary_release_name\E\.\Q$binary_format\E$/,
       version => qr/([0-9\.]+)/,


### PR DESCRIPTION
This fixes #23 